### PR TITLE
level02.[1차] 뉴스 클러스터링

### DIFF
--- a/programmers/난이도별/level02.[1차]_뉴스_클러스터링/SSSOy.java
+++ b/programmers/난이도별/level02.[1차]_뉴스_클러스터링/SSSOy.java
@@ -1,0 +1,61 @@
+import java.util.*;
+
+class Solution {
+    public int solution(String str1, String str2) {
+        int answer = 0;
+        str1 = str1.toLowerCase();
+        str2 = str2.toLowerCase();
+        int str1_len = str1.length();
+        int str2_len = str2.length();
+        
+        List<String> s1 = new ArrayList();
+        List<String> s2 = new ArrayList();
+        
+        for(int i = 0; i < str1_len - 1; i++) {
+            if(str1.charAt(i) >= 'a' && str1.charAt(i) <= 'z' && str1.charAt(i + 1) >= 'a' && str1.charAt(i + 1) <= 'z') {
+                s1.add(str1.substring(i, i + 2));
+            }
+        }
+        for(int i = 0; i < str2_len - 1; i++) {
+            if(str2.charAt(i) >= 'a' && str2.charAt(i) <= 'z'&& str2.charAt(i + 1) >= 'a' && str2.charAt(i + 1) <= 'z')
+                s2.add(str2.substring(i, i + 2));
+        }
+        
+        Collections.sort(s1);
+        Collections.sort(s2);
+        
+        int intersect = 0;
+        int union = 0;
+        
+        Iterator<String> iter1 = s1.iterator();
+        while(iter1.hasNext()) {
+            String s = iter1.next();
+            boolean flag = false;
+            
+            Iterator<String> iter2 = s2.iterator();
+            while(iter2.hasNext()) {
+                if(s.equals(iter2.next())) {
+                    intersect ++;
+                    iter2.remove();
+                    flag = true;
+                    break;
+                }
+            }
+            if(flag)
+                iter1.remove();
+        }
+        
+        union = intersect + s1.size() + s2.size();
+        
+        //intersect_set.retainAll(s2);
+        //s1.addAll(s2);
+        
+        //int intersect = intersect_set.size();
+        //int union = s1.size();
+        
+        double an = union == 0? 1 : (double)intersect / union;
+        answer = (int)(an * 65536);
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
2020/09/18

<2018 KAKAO BLIND RECRUITMENT>
두 집합 A, B 사이의 자카드 유사도 J(A, B)는 두 집합의 교집합 크기를 두 집합의 합집합 크기로 나눈 값으로 정의된다.
입력으로 들어온 두 문자열의 자카드 유사도를 출력한다. 
유사도 값은 0에서 1 사이의 실수이므로, 이를 다루기 쉽도록 65536을 곱한 후에 소수점 아래를 버리고 정수부만 출력한다.


--풀이과정--

1. 대소문자 구분을 하지 않기때문에, 먼저 문자열 모두를 소문자로 바꾸어줌.
2. 문자열을 2글자씩 잘라 list에 넣음.
    ㄴ 처음에는 HashSet을 사용하여 주석부분의 메소드를 이용했는데, 테스트케이스를 보니 같은 문자열이 여러 개 있어도 
        다른 것으로 처리해야했다. 그래서 그래서 중복이 제거되지 않도록 List로 바꾸어 사용하였다.
3. iterator를 사용하여 list안의 값을 하나하나 보며 중복인(교집합) 것들의 개수를 세고, list에서 삭제함.
    ㄴ 처음에는 `for(String s : s1)` 의 형태를 사용하였는데, 이렇게 하면 요소를 삭제할 때 list의 요소 개수가 달라지기 때문에 
        에러가 발생했다. 따라서 iterator를 사용하여 `iter.remove()`로 요소를 삭제하였다.
4.  합집합의 개수를 계산. 교집합인 것들을 제거했기 때문에 교집합 개수 + 남은 것들의 개수로 계산함.
5. 자카드유사도(교집합 / 합집합)을 계산하고, 65536을 곱함.

https://programmers.co.kr/learn/courses/30/lessons/17677